### PR TITLE
Handle numeric in a more platform friendly way

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,15 +178,10 @@ client.predict_lazy([
 ])
 ```
 
-### Compatible filetypes and available field types
+### Compatible filetypes
 The filetypes compatible with sidekick may shown by:
 ```python
 print(sidekick.encode.FILE_EXTENSION_ENCODERS)
-```
-
-Currently supported field types may be shown by:
-```python
-print(sidekick.encode.DTYPE_ENCODERS)
 ```
 
 # Examples

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ TEST_REQUIRED_PACKAGES = [
 
 setup(
     name='sidekick',
-    version='0.2.0',
+    version='0.2.1',
     install_requires=REQUIRED_PACKAGES,
     extras_require={'test': TEST_REQUIRED_PACKAGES},
     packages=find_packages(include='sidekick.*'),

--- a/sidekick/encode.py
+++ b/sidekick/encode.py
@@ -108,12 +108,7 @@ class TextEncoder(Encoder):
         return {str}
 
     def check_shape(self, value: str, shape: Tuple[int]):
-        if len(value) >= shape[0]:
-            warnings.warn(
-                'Text will be cropped to not exceed maximum length. '
-                'Text length: %s characters. '
-                'Maximum length: %s characters.' % (len(value), shape[0])
-            )
+        pass
 
     def encode(self, value):
         return value

--- a/sidekick/encode.py
+++ b/sidekick/encode.py
@@ -230,14 +230,26 @@ FILE_EXTENSION_ENCODERS = {
 
 
 def encode_feature(feature, specs: FeatureSpec) -> Any:
-    encoder = DTYPE_ENCODERS[specs.dtype]
+    # TODO numeric can be both npy and float. Higher
+    # dimensions need to be set to npy right now
+    if specs.dtype == 'numeric' and (len(specs.shape) > 1
+                                     or specs.shape[0] > 1):
+        encoder = DTYPE_ENCODERS['numpy']
+    else:
+        encoder = DTYPE_ENCODERS[specs.dtype]
     encoder.check_type(feature)
     encoder.check_shape(feature, specs.shape)
     return encoder.encode_json(feature)
 
 
 def decode_feature(feature, specs: FeatureSpec) -> Any:
-    encoder = DTYPE_ENCODERS[specs.dtype]
+    # TODO numeric can be both npy and float. Higher
+    # dimensions need to be set to npy right now
+    if specs.dtype == 'numeric' and (len(specs.shape) > 1
+                                     or specs.shape[0] > 1):
+        encoder = DTYPE_ENCODERS['numpy']
+    else:
+        encoder = DTYPE_ENCODERS[specs.dtype]
     decoded = encoder.decode_json(feature)
     encoder.check_type(decoded)
     encoder.check_shape(decoded, specs.shape)

--- a/sidekick/encode.py
+++ b/sidekick/encode.py
@@ -2,7 +2,6 @@ import abc
 import base64
 import io
 import itertools
-import warnings
 from typing import Any, Mapping, Set, Tuple
 
 import numpy as np

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -192,7 +192,7 @@ def test_deployment_categorical():
     categories = 10
     features_in = [
         FeatureSpec('input_1', 'numeric', (1,)),
-        FeatureSpec('input_2', 'numpy', (30,)),
+        FeatureSpec('input_2', 'numeric', (30,)),
     ]
     features_out = [FeatureSpec('output', 'categorical', (categories,))]
     predictions = {str(i): random.random() for i in range(categories)}
@@ -236,8 +236,8 @@ def test_deployment_categorical():
 @responses.activate
 def test_deployment_numpy_autoencoder():
     shape = (100, 10, 3)
-    features_in = [FeatureSpec('input', 'numpy', shape)]
-    features_out = [FeatureSpec('output', 'numpy', shape)]
+    features_in = [FeatureSpec('input', 'numeric', shape)]
+    features_out = [FeatureSpec('output', 'numeric', shape)]
 
     arr = np.random.rand(*shape).astype(np.float32)
     encoded = sidekick.encode.NumpyEncoder().encode_json(arr)

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -27,9 +27,6 @@ def test_text_encoder():
     with pytest.raises(TypeError):
         encoder.check_type(34)
 
-    with pytest.warns(UserWarning):
-        encoder.check_shape(value, shape=(2,))
-
 
 def test_categorical_encoder():
     encoder = CategoricalEncoder()

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -2,8 +2,9 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from sidekick.encode import (CategoricalEncoder, ImageEncoder, NumericEncoder,
-                             NumpyEncoder, TextEncoder)
+from sidekick.encode import (ENCODERS, CategoricalEncoder, ImageEncoder,
+                             NumericEncoder, NumpyEncoder, TextEncoder,
+                             get_encoder)
 
 
 def test_numeric_encoder():
@@ -79,3 +80,10 @@ def test_numpy_encoder():
     encoder.check_type(arr)
     with pytest.raises(TypeError):
         encoder.check_type([1, 2, 3])
+
+
+def test_get_encoder():
+    assert get_encoder(dtype='numeric', shape=(1,)) is ENCODERS['numeric']
+    assert get_encoder(dtype='numeric', shape=(2,)) is ENCODERS['numpy']
+    assert get_encoder(dtype='numeric', shape=(2, 2)) is ENCODERS['numpy']
+    assert get_encoder(dtype='image', shape=(2, 3)) is ENCODERS['image']

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist = py35, py36, py37
 
 [testenv]
+ignore_errors =
+    true
+
 extras =
     test
 
@@ -9,7 +12,6 @@ deps =
     mypy
     isort
     flake8
-    pytest
     coverage
 
 commands =


### PR DESCRIPTION
Handle `numeric` instead of `numpy`. 

Platform is quite strict on datatypes at the moment and forces you to use specific data types. This will change in a near future. 